### PR TITLE
Add new block signifiers

### DIFF
--- a/autoload/gfmdoc.vim
+++ b/autoload/gfmdoc.vim
@@ -65,7 +65,7 @@ function! gfmdoc#WrapLine(width)
         let l:lnum += 1
         " Get the line and check if it seems to be in a block construct or not
         let l:line = getline(lnum)
-        if match(trim(line), '\v^[^#>\-\|]+') != -1 || trim(line) == ''
+        if match(trim(line), '\v^[^#>\-\|\*\+]+') != -1 || trim(line) == ''
             let l:inblock = 'f'
         else
             let l:inblock = 't'


### PR DESCRIPTION
Lists beginning with + and * weren't included in my regex matching for line wrapping, including them now.